### PR TITLE
Proposal: Convenience extension and subspec

### DIFF
--- a/SegueManager.podspec
+++ b/SegueManager.podspec
@@ -24,7 +24,14 @@ Pod::Spec.new do |s|
     ss.ios.deployment_target = '8.0'
     ss.source_files = "src/ios/SegueManager+Rswift.swift"
     ss.dependency "SegueManager/iOS"
-    ss.dependency "R.swift.Library"
+    ss.dependency "R.swift.Library", "~> 1.0.0.beta"
+  end
+
+  s.subspec "Convenience" do |ss|
+    ss.ios.deployment_target = '8.0'
+    ss.source_files = "src/ios/UIViewController+SegueManager.swift"
+    ss.dependency "SegueManager/iOS"
+    ss.dependency "SegueManager/R.swift"
   end
 
   s.subspec "OSX" do |ss|

--- a/SegueManager.xcodeproj/project.pbxproj
+++ b/SegueManager.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D526EF201C302187002B9A32 /* UIViewController+SegueManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D526EF1F1C302187002B9A32 /* UIViewController+SegueManager.swift */; };
 		E24EC7E61BB1605B009AFFB3 /* SegueManager.h in Headers */ = {isa = PBXBuildFile; fileRef = E24EC7E51BB1605B009AFFB3 /* SegueManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E24EC7FE1BB16AC0009AFFB3 /* SegueManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24EC7FD1BB16AC0009AFFB3 /* SegueManager.swift */; };
 		E24EC8011BB16AD3009AFFB3 /* SegueManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24EC7FF1BB16ACB009AFFB3 /* SegueManager.swift */; };
@@ -14,6 +15,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		D526EF1F1C302187002B9A32 /* UIViewController+SegueManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIViewController+SegueManager.swift"; path = "ios/UIViewController+SegueManager.swift"; sourceTree = "<group>"; };
 		E24EC7E21BB1605B009AFFB3 /* SegueManager.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SegueManager.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E24EC7E51BB1605B009AFFB3 /* SegueManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SegueManager.h; sourceTree = "<group>"; };
 		E24EC7E71BB1605B009AFFB3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -83,6 +85,7 @@
 			children = (
 				E24EC7FD1BB16AC0009AFFB3 /* SegueManager.swift */,
 				E28883171C1342C500AE2B8D /* SegueManager+Rswift.swift */,
+				D526EF1F1C302187002B9A32 /* UIViewController+SegueManager.swift */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -211,6 +214,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E28883181C1342C500AE2B8D /* SegueManager+Rswift.swift in Sources */,
+				D526EF201C302187002B9A32 /* UIViewController+SegueManager.swift in Sources */,
 				E24EC7FE1BB16AC0009AFFB3 /* SegueManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/ios/UIViewController+SegueManager.swift
+++ b/src/ios/UIViewController+SegueManager.swift
@@ -1,0 +1,74 @@
+//
+//  UIViewController+SegueManager.swift
+//  SegueManager
+//
+//  Created by Mathijs Kadijk on 27-12-15.
+//  Copyright © 2015 nonstrict. All rights reserved.
+//
+
+import UIKit
+import Rswift
+
+public extension UIViewController {
+  private struct AssociatedKeys {
+    static var SegueManager = "SegueManager"
+  }
+
+  private static var segueManagerPrepareForSegueSwizzleToken: dispatch_once_t = 0
+
+  private var viewControllerAssociatedSegueManager: SegueManager {
+    if let segueManager = objc_getAssociatedObject(self, &AssociatedKeys.SegueManager) as? SegueManager {
+      return segueManager
+    }
+
+    let segueManager = SegueManager(viewController: self)
+    objc_setAssociatedObject(self, &AssociatedKeys.SegueManager, segueManager, .OBJC_ASSOCIATION_RETAIN)
+
+    return segueManager
+  }
+
+  public override class func initialize() {
+    // Make sure this isn't a subclass
+    if self !== UIViewController.self {
+      return
+    }
+
+    dispatch_once(&segueManagerPrepareForSegueSwizzleToken) {
+      let originalSelector = Selector("prepareForSegue:sender:")
+      let swizzledSelector = Selector("segueManager_prepareForSegue:sender:")
+
+      let originalMethod = class_getInstanceMethod(self, originalSelector)
+      let swizzledMethod = class_getInstanceMethod(self, swizzledSelector)
+
+      let didAddMethod = class_addMethod(self, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
+
+      if didAddMethod {
+        class_replaceMethod(self, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod))
+      } else {
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+      }
+    }
+  }
+
+  func segueManager_prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject) {
+    viewControllerAssociatedSegueManager.prepareForSegue(segue)
+  }
+
+  public func performSegue(identifier: String, handler: UIStoryboardSegue -> Void) {
+    viewControllerAssociatedSegueManager.performSegue(identifier, handler: handler)
+  }
+
+  public func performSegue<T>(identifier: String, handler: T -> Void) {
+    viewControllerAssociatedSegueManager.performSegue(identifier, handler: handler)
+  }
+
+  public func performSegue(identifier : String) {
+    performSegue(identifier, handler: { _ in })
+  }
+
+  public func performSegue<Segue, Source, Destination>(
+    segueIdentifier: StoryboardSegueIdentifier<Segue, Source, Destination>,
+    handler: TypedStoryboardSegueInfo<Segue, Source, Destination> -> Void) {
+      viewControllerAssociatedSegueManager.performSegue(segueIdentifier, handler: handler)
+  }
+}


### PR DESCRIPTION
**This PR contains:**
- Convenience subspec that depends on the iOS / R.swift subspecs
- `UIViewController` extension containing:
  - associated segue manager instance
  - swizzled method to provide default implementation for prepareForSegue calling them on the associated segue manager
  - proxy methods to perform segues

**The good:**
- Lazy initialization of the SegueManager
- `SegueManager` is kept alive by the `UIViewController` instance, so when the VC deallocs the manager goes with it
- Closer to what you're used to write
- Backwards compatible with vanilla iOS code, won't break anything
- Zero boilerplate, we go from this:

``` swift
import SegueManager

class MasterViewController: UIViewController {

  lazy var segueManager: SegueManager = {
    // SegueManager based on the current view controller
    return SegueManager(viewController: self)
  }()

  override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
    segueManager.prepareForSegue(segue)
  }

  func buttonTouched() {
    segueManager.performSegue(R.segue.someSegue) { _ in
      print("woohoo!")
    }
  }
}
```

to this:

``` swift
import SegueManager

class MasterViewController: UIViewController {
  func buttonTouched() {
    performSegue(R.segue.someSegue) { _ in
      print("woohoo!")
    }
  }
}
```

**The bad:**
- Uses ObjC associated values to save to retain the `SegueManager`, I don't consider this a problem, but pure Swift could be nicer. I tried using a caching system, but it is much more and error prone code with the same effect in the end...
- Uses method swizzling to implement the `prepareForSegue` method, this I think should be opt-in I believe. Apple docs state the default implementation does nothing, so we shouldn't break anything with this. But other libraries swizzling the same methods could give strange effects.
- Providing this as a subspec and having the R.swift compatible version as a subspec is a bit messy. Either the Convenience spec depends upon the R.swift spec or we have to create an extra ConvenienceWithR.swift spec...

**Conclusion:**
It feels really clean, nice and transparent to use as end user. We now often create all kinds of subclasses of ViewControllers in our projects. I think this could be a nice alternative. If it feels to ugly/risky to put into the main spec, then I would propose to provide this as a subspec.

_Todo:_
- [ ] Decide what to do with this proposal
- [ ] Update Readme/docs & example projects
- [ ] Create OS X version?! 
